### PR TITLE
added a simple test for las2dem

### DIFF
--- a/tests/test_las2dem.py
+++ b/tests/test_las2dem.py
@@ -1,0 +1,18 @@
+__author__ = 'weiqin'
+
+import os
+import subprocess
+from terraref.laser3d import generate_tif_from_las
+
+dire = os.path.join(os.path.dirname(__file__), 'data/')
+input = dire + 'newmerge1.las'
+output = dire+'newmerge1.tif'
+
+def test_las_to_tif():
+    generate_tif_from_las(input, output)
+    assert os.path.isfile(output)
+    os.remove(output)
+
+if __name__ == '__main__':
+    subprocess.call(['python -m pytest test_las2dem.py -p no:cacheprovider'], shell=True)
+


### PR DESCRIPTION
the test itself is simple, but now my concern is that: the test is running in the docker container as well.
I tried on my local end, within the docker container as PLYTEST/test_las2dem.py and PLYTEST/data/newmerge1.las ( this is same structured as our package). The test passed with condition that test data and test code is under container directory. So the next step I can think of is to install the new terraref.laser3d once PR merged in the container and run test.
Another thing came to my mind is that, do we still need lasmerge test now? So as what I understand, we are merging las files by merging lists of ply files and then convert to las file. So if needed, I can pass in a list of ply files in test_ply2las. 